### PR TITLE
update version 1.2.4

### DIFF
--- a/com.iche2.gai.yaml
+++ b/com.iche2.gai.yaml
@@ -28,6 +28,7 @@ modules:
       - type: archive
         only-arches:
           - x86_64
+        # submit again
         # path: "Gai-1.2.1-bin-linux-x86_64.tar.gz"
         url: https://webpath.iche2.com/release/Gai-1.2.1-bin-linux-x86_64.tar.gz
         sha256: 164bcdfeb550188bb903866618346d04f7386aef817f9260547969472fc1757c

--- a/com.iche2.gai.yaml
+++ b/com.iche2.gai.yaml
@@ -28,8 +28,8 @@ modules:
       - type: archive
         only-arches:
           - x86_64
-        # path: "Gai-1.2.0-bin-linux-x86_64.tar.gz"
-        url: https://webpath.iche2.com/release/Gai-1.2.0-bin-linux-x86_64.tar.gz
-        sha256: c300238911e3cecf1caeea73a27f392a9b8e367cfc043ba7eebd2e403cc99492
+        # path: "Gai-1.2.1-bin-linux-x86_64.tar.gz"
+        url: https://webpath.iche2.com/release/Gai-1.2.1-bin-linux-x86_64.tar.gz
+        sha256: 164bcdfeb550188bb903866618346d04f7386aef817f9260547969472fc1757c
         dest-filename: gai.tar.gz
         strip-components: 1

--- a/com.iche2.gai.yaml
+++ b/com.iche2.gai.yaml
@@ -1,6 +1,6 @@
 app-id: com.iche2.gai
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: gai
 separate-locales: false
@@ -30,7 +30,7 @@ modules:
           - x86_64
         # submit again
         # path: "Gai-1.2.1-bin-linux-x86_64.tar.gz"
-        url: https://webpath.iche2.com/release/Gai-1.2.1-bin-linux-x86_64.tar.gz
-        sha256: 164bcdfeb550188bb903866618346d04f7386aef817f9260547969472fc1757c
+        url: https://webpath.iche2.com/release/Gai-1.2.4-bin-linux-x86_64.tar.gz
+        sha256: 1ba37a1f191b7db7168e1fca7b89543fe3eb3084af2994a8dd212ae75f6f80b5
         dest-filename: gai.tar.gz
         strip-components: 1


### PR DESCRIPTION
# 1.2.4
* support Gemini 3.0 Flash preview.
* support Gemini 2.5 Flash image generation.
* support Imagen 4.0 generate (usagemode: serveonly).
* support uploading large files and storing them for 48 hours.
* support secure tunneling for geo-blocking bypass (usagemode: forwardonly).
* remove Gemini 2.0 models are now shut down.