### PR TITLE
new version: v1.2.6 Gai (Generative-AI tools for beginner)

### DIFF
--- a/com.iche2.gai.yaml
+++ b/com.iche2.gai.yaml
@@ -28,9 +28,8 @@ modules:
       - type: archive
         only-arches:
           - x86_64
-        # submit again
-        # path: "Gai-1.2.1-bin-linux-x86_64.tar.gz"
-        url: https://webpath.iche2.com/release/Gai-1.2.4-bin-linux-x86_64.tar.gz
-        sha256: 1ba37a1f191b7db7168e1fca7b89543fe3eb3084af2994a8dd212ae75f6f80b5
+        # path: "Gai-1.2.6-bin-linux-x86_64.tar.gz"
+        url: https://webpath.iche2.com/release/Gai-1.2.6-bin-linux-x86_64.tar.gz
+        sha256: 6de30bcc732a74930e331ef6be98dcda1422dc3835ad1fdbe0f108204e88acfd
         dest-filename: gai.tar.gz
         strip-components: 1


### PR DESCRIPTION
## 1.2.6
 - support Gemini 3.1 Flash Lite preview.
 - support Gemini 3.1 Flash Image preview (Nano Banana 2).
 - home input: support short-term contextual memory.
 - in-app help: fixed and verified all broken links.
 - in-app help: learn how to make AI work more cost-effectively and efficiently for you.
 - more models for paid tiers: access gemini pro and multimodal (image) models.
 - context caching for paid tiers: reuse data to cut costs and boost speed.
 - detailed token breakdown: input/output, caching, and multimodal metrics.
 - prompt attachments: increased inline file limit to 50MB.
 - optimized UI loading: added a 90s auto-timeout.
 - fixed: image gen for usage mode: local.
 - fixed: can launch url in markdown content.